### PR TITLE
重构 kindle.py 文件，增加 output 文件夹存放输出文件

### DIFF
--- a/kindle.py
+++ b/kindle.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
@@ -7,16 +8,23 @@ import shutil
 
 
 class book:
-    def __init__(self, name, author):
-        self.name = name
-        self.author = author
-        self.contents = []
+    """
+    图书类，每本书有 书名（name），作者（author），摘录内容列表（contents）
+    摘录内容列表中，每个元素是键为 pos 和 content 的词典
+    """
+    def __init__(self, name, author, pos, content):
+        self.name, self.author = name, author
+        self.contents = [{'pos': pos, 'content': content}]
 
     def add(self, pos, content):
-        if len(self.contents) > 0:
-            if self.contents[-1][0] == pos:
+        """
+        向图书添加新的摘录内容及其位置
+        """
+        if self.contents:
+            if self.contents[-1]['pos'] == pos:
                 del self.contents[-1]
-        self.contents.append((pos, content))
+        self.contents.append({'pos': pos, 'content': content})
+
 
 def strip(func):
     """
@@ -31,8 +39,9 @@ def strip(func):
         return func(striped_arg)
     return wrapper
 
+
 @strip
-def handleBookName(text):
+def extract_title(text):
     """
     提取书本名称及作者
     """
@@ -48,19 +57,21 @@ def handleBookName(text):
     name_regex = r'^(.*)'
     special_name_regex = r'[:](.*?)[ (]'
 
-    if not re.search(special_name_regex, name_part):
+    special_name_found = re.search(special_name_regex, name_part)
+    if special_name_found:
+        name = special_name_found.group(1)
+    else:
         name_found = re.search(name_regex, name_part)
         if name_found:
             name = name_found.group(1)
         else:
             raise ValueError('未能匹配到书本名称')
-    else:
-        name = special_name_res.group(1)
 
     return name.strip(), author.strip()
 
+
 @strip
-def handlePos(text):
+def extract_position(text):
     """
     提取标注位置
     """
@@ -71,8 +82,9 @@ def handlePos(text):
     else:
         return 0  # 无法匹配出位置，以 0 代替
 
+
 @strip
-def handleContent(text):
+def extract_content(text):
     """
     提取标注内容
     """
@@ -92,39 +104,55 @@ def handleContent(text):
 
     return re.sub(r'(\s+)', '\n', text)
 
-bookList = {}
-srcFile = open('My Clippings.txt', 'r', encoding='utf-8')
-allPieces = srcFile.read().replace(r'\ufeff', '').split("==========\n")
-del allPieces[-1]
 
-for paragraph in allPieces:
-    name_line, pos_line, _, content_block = paragraph.split('\n', 3)
-    bookname, author = handleBookName(name_line)
-    pos = handlePos(pos_line)
-    content = handleContent(content_block)
+def parse(allPieces):
+    """
+    解析各段落
+    """
+    books = {}
+    for paragraph in allPieces:
+        title_line, pos_line, _, content_block = paragraph.split('\n', 3)
+        title, author = extract_title(title_line)
+        pos = extract_position(pos_line)
+        content = extract_content(content_block)
 
-    if len(content) > 3:
-        if bookname not in bookList:
-            the_book = book(bookname, author)
-            the_book.add(pos, content)
-            bookList[bookname] = the_book
+        if len(content) > 3:
+            if title not in books:
+                books[title] = book(title, author, pos, content)
+            else:
+                books[title].add(pos, content)
+    return books
+
+
+def main():
+    OUTPUT_DIR = 'output'
+
+    srcFile = open('My Clippings.txt', 'r', encoding='utf-8')
+    pieces = srcFile.read().replace(r'\ufeff', '').split("==========\n")
+    # 最后一行是"==========\n"，因而 pieces[-1] 为空
+    del pieces[-1]
+
+    books = parse(pieces)
+
+    for book in books.values():
+        title = book.name
+        print("Generating ...", book.name)
+
+        if not os.path.exists(OUTPUT_DIR):
+            os.makedirs(OUTPUT_DIR)
+
+        if os.path.exists(OUTPUT_DIR + os.path.sep + title):
+            shutil.rmtree(OUTPUT_DIR + os.path.sep + title)
+            os.makedirs(OUTPUT_DIR + os.path.sep + title)
         else:
-            bookList[bookname].add(pos, content)
+            os.makedirs(OUTPUT_DIR + os.path.sep + title)
 
+        file = open(OUTPUT_DIR + os.path.sep + title + os.path.sep + title + '.txt', 'w', encoding='utf-8')
 
-for book in bookList.values():
+        for content_info in book.contents:
+            file.write(content_info['content'] + '\n\n')
+        file.close()
+    print("Done.")
 
-    bookname = book.name
-    print("Generating ...", book.name)
-
-    if os.path.exists(bookname):
-        shutil.rmtree(bookname)
-        os.makedirs(bookname)
-    else:
-        os.makedirs(bookname)
-    file = open(bookname + '/' + bookname + '.txt', 'w', encoding='utf-8')
-
-    for content in book.contents:
-        file.write(content[1] + '\n\n')
-    file.close()
-print("Done.")
+if __name__ == '__main__':
+    main()

--- a/kindle.py
+++ b/kindle.py
@@ -45,7 +45,7 @@ def handleBookName(text):
         name_part = text
         author = ''
 
-    name_regex = r'^(.*)' # r'[\ufeff](.*)'
+    name_regex = r'^(.*)'
     special_name_regex = r'[:](.*?)[ (]'
 
     if not re.search(special_name_regex, name_part):
@@ -94,7 +94,7 @@ def handleContent(text):
 
 bookList = {}
 srcFile = open('My Clippings.txt', 'r', encoding='utf-8')
-allPieces = srcFile.read().split("==========\n")
+allPieces = srcFile.read().replace(r'\ufeff', '').split("==========\n")
 del allPieces[-1]
 
 for paragraph in allPieces:

--- a/kindle.py
+++ b/kindle.py
@@ -120,12 +120,12 @@ def read_clippings_file():
     return pieces
 
 
-def parse(allPieces):
+def parse(pieces):
     """
     解析各段落
     """
     books = {}
-    for paragraph in allPieces:
+    for paragraph in pieces:
         title_line, pos_line, _, content_block = paragraph.split('\n', 3)
         title, author = extract_title(title_line)
         pos = extract_position(pos_line)


### PR DESCRIPTION
1. 按照 PEP8 重构 kindle.py 代码风格; 
2. 增加 output 文件夹，所有输出的文件将添加到 output 文件夹内; 
3. 修改 contents 列表中每个元素为 dict 结构，提高读写时的代码可读性
4. 将 kindle.py 文件变为可执行; 